### PR TITLE
Update scd.m

### DIFF
--- a/scd.m
+++ b/scd.m
@@ -84,8 +84,10 @@ classdef scd
             
             y=importdata(key_filename);
             obj.masses=cellstr(num2str(y.data(1,:)'));
-            
-            obj.masses=cellstr(num2str(y.data(1,:)'));
+
+            % remove space from 2-digit weights incurred by cellstr (e.g. ' 89' -> '89' Yttrium)
+            obj.masses=strrep(obj.masses,' ','');
+ 
             obj.num_masses=length(obj.masses);
             obj.wellLabels=y.textdata(2:end);
             obj.num_codes=length(obj.wellLabels);


### PR DESCRIPTION
When obj.masses is created with the cellstr function, 2-digit barcode masses (like 89 Yttrium) are converted to 3 characters as ' MM' ( ' 89') if they are read alongside 3-digit barcode masses (like Palladiums). The appended space will not be found in the fcs file, so this mass will not be recognized and will cause an error. The proposed edit removes any spaces present in obj.masses, avoiding this problem. Alternatively, a more elegant solution might create obj.masses in a way that does not require all masses to share the same number of characters, thus avoiding the introduction of an extra space.